### PR TITLE
Fix page title include 'Laravel'

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -27,7 +27,7 @@
             })();
         </script>
 
-        <title inertia>{{ config('app.name', 'Laravel') }}</title>
+        <title inertia>{{ config('app.name', 'LOSLC') }}</title>
 
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />


### PR DESCRIPTION
Fix page title showing Laravel at the end