### PR TITLE
Fix: Add expose Decorator to DTO classes non-exposed props

### DIFF
--- a/backend/src/accessmgt/accessmgt.controller.ts
+++ b/backend/src/accessmgt/accessmgt.controller.ts
@@ -500,6 +500,7 @@ export class AccessmgtController {
   @BypassRole({ roleName: "superadmin" })
   @UseGuards(AuthGuard, AccessGuard)
   async createRole(@Body() createRoleDTO: CreateRoleDTO): Promise<RoleDTO> {
+    console.log(createRoleDTO)
     return this.accessmgtService.createRole(createRoleDTO);
   }
 
@@ -549,6 +550,7 @@ export class AccessmgtController {
   async createPermission(
     @Body() createPermissionDTO: CreatePermissionDTO,
   ): Promise<PermissionDTO> {
+    console.log(createPermissionDTO);
     return this.accessmgtService.createPermission(createPermissionDTO);
   }
 

--- a/backend/src/accessmgt/accessmgt.dto.ts
+++ b/backend/src/accessmgt/accessmgt.dto.ts
@@ -1,6 +1,7 @@
 import { NewPermission, NewRole, Permission, Role } from "@/core/db/schema";
 import { IsNotEmpty, Max, Min } from "class-validator";
 import { ActionType, ResourceType } from "./accessmgt.types";
+import { Expose } from "class-transformer";
 
 interface GetUserRolesInterface {
   userId: string;
@@ -35,64 +36,107 @@ interface PermissionAssignmentDTOInterface {
 }
 
 export class GetUserRolesDTO implements GetUserRolesInterface {
+  @Expose()
   userId: string;
+  
+  @Expose()
   all?: boolean;
 
+  @Expose()
   @Max(100)
   limit?: number;
 
+  @Expose()
   @Min(0)
   offset?: number;
 }
 
 export class GetRolePermissionsDTO implements GetRolePermissionsInterface {
+  @Expose()
   roleId: string;
+  
+  @Expose()
   all?: boolean;
+  
+  @Expose()
   @Max(100)
   limit?: number;
+  
+  @Expose()
   @Min(0)
   offset?: number;
 }
 
 export class RoleDTO implements RoleDTOInterface {
+  @Expose()
   id: string;
+  
+  @Expose()
   name: string | null;
+  
+  @Expose()
   description: string | null;
+  
+  @Expose()
   createdAt: Date;
 }
 
 export class PermissionDTO implements PermissionDTOInterface {
+  @Expose()
   id: string;
+  
+  @Expose()
   name: string | null;
+  
+  @Expose()
   action: string;
+  
+  @Expose()
   resource: string;
+  
+  @Expose()
   resourceId: string | null;
+  
+  @Expose()
   description: string | null;
+  
+  @Expose()
   createdAt: Date;
 }
 
 export class CreateRoleDTO implements CreateRoleDTOInterface {
+  @Expose()
   name: string | null;
+  
+  @Expose()
   description: string | null;
 }
 
 export class CreatePermissionDTO implements CreatePermissionDTOInterface {
+  @Expose()
   name: string | null;
 
+  @Expose()
   @IsNotEmpty()
   action: ActionType;
 
+  @Expose()
   @IsNotEmpty()
   resource: ResourceType;
 
+  @Expose()
   resourceId: string | null;
+  
+  @Expose()
   description: string | null;
 }
 
 export class RoleAssignmentDTO implements RoleAssignmentDTOInterface {
+  @Expose()
   @IsNotEmpty()
   userId: string;
 
+  @Expose()
   @IsNotEmpty()
   roleId: string;
 }
@@ -100,9 +144,11 @@ export class RoleAssignmentDTO implements RoleAssignmentDTOInterface {
 export class PermissionAssignmentDTO
   implements PermissionAssignmentDTOInterface
 {
+  @Expose()
   @IsNotEmpty()
   roleId: string;
 
+  @Expose()
   @IsNotEmpty()
   permissionId: string;
 }

--- a/backend/src/accessmgt/accessmgt.service.ts
+++ b/backend/src/accessmgt/accessmgt.service.ts
@@ -141,10 +141,7 @@ export class AccessmgtService {
           eq(userRolesTable.roleId, rolesTable.id),
         ),
       )
-      .innerJoin(
-        rolesTable,
-        eq(rolesTable.id, userRolesTable.roleId),
-      )
+      .innerJoin(rolesTable, eq(rolesTable.id, userRolesTable.roleId))
       .innerJoin(
         rolePermissionsTable,
         and(
@@ -261,7 +258,14 @@ export class AccessmgtService {
   }
 
   async createRole(props: CreateRoleDTO): Promise<RoleDTO> {
-    const [role] = await db.insert(rolesTable).values(props).returning();
+    console.log(props)
+    const [role] = await db
+      .insert(rolesTable)
+      .values({
+        name: props.name,
+        description: props.description,
+      })
+      .returning();
     return role;
   }
 

--- a/backend/src/auth/auth.dto.ts
+++ b/backend/src/auth/auth.dto.ts
@@ -1,4 +1,5 @@
 import { IsEmail, IsNotEmpty, MinLength } from "class-validator";
+import { Expose } from "class-transformer";
 
 interface RegisterDTOInterface {
   email: string;
@@ -34,39 +35,49 @@ interface PasswordResetDTOInterface {
 }
 
 export class RegisterDTO implements RegisterDTOInterface {
+  @Expose()
   @IsEmail()
   email: string;
 
+  @Expose()
   @IsNotEmpty()
   username: string;
 
+  @Expose()
   @IsNotEmpty()
   fullName: string;
 
+  @Expose()
   @MinLength(8)
   password: string;
 
+  @Expose()
   @MinLength(8)
   confirmPassword: string;
 }
 
 export class LoginDTO implements LoginDTOInterface {
+  @Expose()
   @IsEmail()
   email: string;
 
+  @Expose()
   @MinLength(8)
   password: string;
 }
 
 export class OtpVerificationDTO implements OtpVerificationDTOInterface {
+  @Expose()
   @IsNotEmpty()
   token: string;
 }
 
 export class AccountVerificationDTO implements AccountVerificationDTOInterface {
+  @Expose()
   @IsNotEmpty()
   authSessionId: string;
 
+  @Expose()
   @IsNotEmpty()
   authSessionToken: string;
 }
@@ -74,20 +85,25 @@ export class AccountVerificationDTO implements AccountVerificationDTOInterface {
 export class PasswordResetRequestDTO
   implements PasswordResetRequestDTOInterface
 {
+  @Expose()
   @IsEmail()
   email: string;
 }
 
 export class PasswordResetDTO implements PasswordResetDTOInterface {
+  @Expose()
   @IsNotEmpty()
   sessionId: string;
 
+  @Expose()
   @IsNotEmpty()
   token: string;
 
+  @Expose()
   @MinLength(8)
   newPassword: string;
 
+  @Expose()
   @MinLength(8)
   confirmNewPassword: string;
 }

--- a/backend/src/blog/blog.dto.ts
+++ b/backend/src/blog/blog.dto.ts
@@ -1,195 +1,244 @@
 import { IsNotEmpty, IsOptional, IsBoolean, IsString, IsUUID, IsArray, IsInt, Min, Max } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
-import { Transform, Type } from "class-transformer";
+import { Transform, Type, Expose } from "class-transformer";
 
 // Blog Post DTOs
 export class BlogPostDTO {
   @ApiProperty()
+  @Expose()
   id: string;
 
   @ApiProperty()
+  @Expose()
   title: string;
 
   @ApiProperty()
+  @Expose()
   description: string;
 
   @ApiProperty()
+  @Expose()
   content: string;
 
   @ApiProperty()
+  @Expose()
   authorId: string;
 
   @ApiProperty()
+  @Expose()
   categoryId: string | null;
 
   @ApiProperty()
+  @Expose()
   coverImageId: string | null;
 
   @ApiProperty()
+  @Expose()
   featured: boolean;
 
   @ApiProperty()
+  @Expose()
   published: boolean;
 
   @ApiProperty()
+  @Expose()
   archived: boolean;
 
   @ApiProperty()
+  @Expose()
   createdAt: Date;
 
   @ApiProperty()
+  @Expose()
   updatedAt: Date | null;
 }
 
 export class CreateBlogPostDTO {
   @IsNotEmpty()
   @IsString()
+  @Expose()
   title: string;
 
   @IsNotEmpty()
   @IsString()
+  @Expose()
   description: string;
 
   @IsNotEmpty()
   @IsString()
+  @Expose()
   content: string;
 
   @IsOptional()
   @IsUUID()
+  @Expose()
   categoryId?: string;
 
   @IsOptional()
   @IsUUID()
+  @Expose()
   coverImageId?: string;
 
   @IsOptional()
   @IsBoolean()
+  @Expose()
   featured?: boolean;
 
   @IsOptional()
   @IsBoolean()
+  @Expose()
   published?: boolean;
 
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
+  @Expose()
   tags?: string[];
 }
 
 export class UpdateBlogPostDTO {
   @IsOptional()
   @IsString()
+  @Expose()
   title?: string;
 
   @IsOptional()
   @IsString()
+  @Expose()
   description?: string;
 
   @IsOptional()
   @IsString()
+  @Expose()
   content?: string;
 
   @IsOptional()
   @IsUUID()
+  @Expose()
   categoryId?: string;
 
   @IsOptional()
   @IsUUID()
+  @Expose()
   coverImageId?: string;
 
   @IsOptional()
   @IsBoolean()
+  @Expose()
   featured?: boolean;
 
   @IsOptional()
   @IsBoolean()
+  @Expose()
   published?: boolean;
 
   @IsOptional()
   @IsBoolean()
+  @Expose()
   archived?: boolean;
 
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
+  @Expose()
   tags?: string[];
 }
 
 // Comment DTOs
 export class BlogCommentDTO {
   @ApiProperty()
+  @Expose()
   id: string;
 
   @ApiProperty()
+  @Expose()
   postId: string;
 
   @ApiProperty()
+  @Expose()
   authorId: string;
 
   @ApiProperty()
+  @Expose()
   parentId: string | null;
 
   @ApiProperty()
+  @Expose()
   content: string;
 }
 
 export class CreateCommentDTO {
   @IsNotEmpty()
   @IsString()
+  @Expose()
   content: string;
 
   @IsOptional()
   @IsUUID()
+  @Expose()
   parentId?: string;
 }
 
 export class UpdateCommentDTO {
   @IsNotEmpty()
   @IsString()
+  @Expose()
   content: string;
 }
 
 // Like DTOs
 export class BlogLikeDTO {
   @ApiProperty()
+  @Expose()
   id: string;
 
   @ApiProperty()
+  @Expose()
   likerId: string;
 
   @ApiProperty()
+  @Expose()
   postId: string;
 
   @ApiProperty()
+  @Expose()
   likedAt: Date;
 }
 
 export class ToggleLikeResponseDTO {
   @ApiProperty({ description: 'Whether the post is now liked or not' })
+  @Expose()
   liked: boolean;
 
   @ApiProperty({ required: false, description: 'The like object if the post was liked' })
+  @Expose()
   like?: BlogLikeDTO;
 
   @ApiProperty({ description: 'Success message' })
+  @Expose()
   message: string;
 }
 
 // View DTOs
 export class BlogViewDTO {
   @ApiProperty()
+  @Expose()
   id: string;
 
   @ApiProperty()
+  @Expose()
   viewerId: string | null;
 
   @ApiProperty()
+  @Expose()
   postId: string;
 
   @ApiProperty()
+  @Expose()
   viewedAt: Date;
 
   @ApiProperty()
+  @Expose()
   viewTime: number;
 }
 
@@ -198,48 +247,58 @@ export class CreateViewDTO {
   @IsInt()
   @Min(0)
   @Max(86400) // Max 24 hours in seconds
+  @Expose()
   viewTime?: number;
 }
 
 // Category DTOs
 export class BlogCategoryDTO {
   @ApiProperty()
+  @Expose()
   id: string;
 
   @ApiProperty()
+  @Expose()
   name: string;
 }
 
 export class CreateCategoryDTO {
   @IsNotEmpty()
   @IsString()
+  @Expose()
   name: string;
 }
 
 export class UpdateCategoryDTO {
   @IsNotEmpty()
   @IsString()
+  @Expose()
   name: string;
 }
 
 // Tag DTOs
 export class BlogTagDTO {
   @ApiProperty()
+  @Expose()
   id: string;
 
   @ApiProperty()
+  @Expose()
   name: string;
 
   @ApiProperty()
+  @Expose()
   userId: string;
 
   @ApiProperty()
+  @Expose()
   createdAt: Date;
 }
 
 export class CreateTagDTO {
   @IsNotEmpty()
   @IsString()
+  @Expose()
   name: string;
 }
 // Query DTOs
@@ -248,6 +307,7 @@ export class GetBlogPostsQueryDTO {
   @IsInt()
   @Min(0)
   @Type(() => Number)
+  @Expose()
   offset?: number = 0;
 
   @IsOptional()
@@ -255,26 +315,32 @@ export class GetBlogPostsQueryDTO {
   @Min(1)
   @Max(100)
   @Type(() => Number)
+  @Expose()
   limit?: number = 20;
 
   @IsOptional()
   @IsUUID()
+  @Expose()
   categoryId?: string;
 
   @IsOptional()
   @IsString()
+  @Expose()
   tag?: string;
 
   @IsOptional()
   @IsBoolean()
   @Transform(({value}) => value === 'true')
+  @Expose()
   featured?: boolean;
 
   @IsOptional()
   @IsString()
+  @Expose()
   authorId?: string;
 
   @IsOptional()
   @IsString()
+  @Expose()
   query?: string;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,15 +8,21 @@ import { getEnv } from "./core/env";
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors({
-    origin: getEnv("CORS_ORIGIN").split(",").map((origin) => origin.trim()),
+    origin: getEnv("CORS_ORIGIN")
+      .split(",")
+      .map((origin) => origin.trim()),
     methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
     credentials: true,
-  })
+  });
   app.use(cookieParser());
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
       whitelist: true,
+      forbidNonWhitelisted: false,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
     }),
   );
 

--- a/backend/src/users/users.dto.ts
+++ b/backend/src/users/users.dto.ts
@@ -1,5 +1,6 @@
 import { IsNotEmpty, IsString, MaxLength, MinLength } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
 import { User } from "@/core/db/schema";
 
 export interface UserDTO {
@@ -44,6 +45,7 @@ export interface UserBanResponseDTO {
 }
 
 export class UpdateUserInfoDTO {
+  @Expose()
   @ApiProperty({
     description: "The user's full name",
     example: "John Doe",
@@ -58,6 +60,7 @@ export class UpdateUserInfoDTO {
 }
 
 export class GetUsersDTO {
+  @Expose()
   @ApiProperty({
     description: "Maximum number of users to return",
     example: 20,
@@ -67,6 +70,7 @@ export class GetUsersDTO {
   })
   limit?: number = 20;
 
+  @Expose()
   @ApiProperty({
     description: "Number of users to skip for pagination",
     example: 0,


### PR DESCRIPTION
This pull request introduces improvements to the DTO (Data Transfer Object) classes across multiple modules by adding the `@Expose()` decorator from `class-transformer` to all DTO properties. This ensures that only explicitly marked fields are included during serialization and deserialization, increasing security and clarity in API responses. Additionally, there are some minor logging additions and small refactoring in the access management service and controller.

The most important changes are:

**DTO Serialization Improvements:**

* Added `@Expose()` decorators to all properties in DTO classes in `auth`, `blog`, `accessmgt`, and `users` modules to control which fields are exposed during object transformation. This affects files such as `auth.dto.ts`, `blog.dto.ts`, `accessmgt.dto.ts`, and `users.dto.ts`. [[1]](diffhunk://#diff-3fa6c24f91e8cbd65360c5e2fd04c5a2169a68a55a61068720ce8fe25b3ae399R4) [[2]](diffhunk://#diff-3fa6c24f91e8cbd65360c5e2fd04c5a2169a68a55a61068720ce8fe25b3ae399R39-R151) [[3]](diffhunk://#diff-dcb253709def32c3da7faf4110aaa07a62cfb2d2269b69f56ab0ccb4675c3b17R2) [[4]](diffhunk://#diff-dcb253709def32c3da7faf4110aaa07a62cfb2d2269b69f56ab0ccb4675c3b17R38-R106) [[5]](diffhunk://#diff-5d9f7e2b3f66fad489de4d65d44471ecc3278224148986b0ab8b9697431a4131L3-R241) [[6]](diffhunk://#diff-5d9f7e2b3f66fad489de4d65d44471ecc3278224148986b0ab8b9697431a4131R250-R301) [[7]](diffhunk://#diff-5d9f7e2b3f66fad489de4d65d44471ecc3278224148986b0ab8b9697431a4131R310-R344) [[8]](diffhunk://#diff-513a956b650d991bac0e47191d42c2bc607d7868a6054e614c5d5b825c745cebR3) [[9]](diffhunk://#diff-513a956b650d991bac0e47191d42c2bc607d7868a6054e614c5d5b825c745cebR48) [[10]](diffhunk://#diff-513a956b650d991bac0e47191d42c2bc607d7868a6054e614c5d5b825c745cebR63) [[11]](diffhunk://#diff-513a956b650d991bac0e47191d42c2bc607d7868a6054e614c5d5b825c745cebR73)

**Validation and Transformation Pipeline:**

* Updated the global validation pipe in `main.ts` to enable implicit type conversion and set `forbidNonWhitelisted` to `false`, supporting more flexible request payloads.

**Access Management Logging and Refactoring:**

* Added logging of DTO payloads in `AccessmgtController` methods for `createRole` and `createPermission` to aid in debugging. [[1]](diffhunk://#diff-5ff893bf86677386d14a4dd2e060391ea6f4d95feb23b901a6d674356a2b319fR503) [[2]](diffhunk://#diff-5ff893bf86677386d14a4dd2e060391ea6f4d95feb23b901a6d674356a2b319fR553)
* Refactored `createRole` in `AccessmgtService` to destructure DTO properties explicitly and added a debug log.
* Minor formatting adjustment in a join statement in `AccessmgtService`.