### PR TITLE
feat(dto): replace @Expose decorators with proper validation decorators

### DIFF
--- a/backend/src/accessmgt/accessmgt.dto.ts
+++ b/backend/src/accessmgt/accessmgt.dto.ts
@@ -1,7 +1,7 @@
 import { NewPermission, NewRole, Permission, Role } from "@/core/db/schema";
-import { IsNotEmpty, Max, Min } from "class-validator";
+import { IsNotEmpty, IsOptional, Max, Min } from "class-validator";
 import { ActionType, ResourceType } from "./accessmgt.types";
-import { Expose } from "class-transformer";
+import { Transform, Type } from "class-transformer";
 
 interface GetUserRolesInterface {
   userId: string;
@@ -36,107 +36,81 @@ interface PermissionAssignmentDTOInterface {
 }
 
 export class GetUserRolesDTO implements GetUserRolesInterface {
-  @Expose()
   userId: string;
   
-  @Expose()
   all?: boolean;
 
-  @Expose()
   @Max(100)
   limit?: number;
 
-  @Expose()
   @Min(0)
   offset?: number;
 }
 
 export class GetRolePermissionsDTO implements GetRolePermissionsInterface {
-  @Expose()
   roleId: string;
   
-  @Expose()
   all?: boolean;
   
-  @Expose()
   @Max(100)
   limit?: number;
   
-  @Expose()
   @Min(0)
   offset?: number;
 }
 
 export class RoleDTO implements RoleDTOInterface {
-  @Expose()
   id: string;
   
-  @Expose()
   name: string | null;
   
-  @Expose()
   description: string | null;
   
-  @Expose()
   createdAt: Date;
 }
 
 export class PermissionDTO implements PermissionDTOInterface {
-  @Expose()
   id: string;
   
-  @Expose()
   name: string | null;
   
-  @Expose()
   action: string;
   
-  @Expose()
   resource: string;
   
-  @Expose()
   resourceId: string | null;
   
-  @Expose()
   description: string | null;
   
-  @Expose()
   createdAt: Date;
 }
 
 export class CreateRoleDTO implements CreateRoleDTOInterface {
-  @Expose()
+  @IsOptional()
   name: string | null;
   
-  @Expose()
+  @IsOptional()
   description: string | null;
 }
 
 export class CreatePermissionDTO implements CreatePermissionDTOInterface {
-  @Expose()
   name: string | null;
 
-  @Expose()
   @IsNotEmpty()
   action: ActionType;
 
-  @Expose()
   @IsNotEmpty()
   resource: ResourceType;
 
-  @Expose()
   resourceId: string | null;
   
-  @Expose()
   description: string | null;
 }
 
 export class RoleAssignmentDTO implements RoleAssignmentDTOInterface {
-  @Expose()
   @IsNotEmpty()
   userId: string;
 
-  @Expose()
   @IsNotEmpty()
   roleId: string;
 }
@@ -144,11 +118,9 @@ export class RoleAssignmentDTO implements RoleAssignmentDTOInterface {
 export class PermissionAssignmentDTO
   implements PermissionAssignmentDTOInterface
 {
-  @Expose()
   @IsNotEmpty()
   roleId: string;
 
-  @Expose()
   @IsNotEmpty()
   permissionId: string;
 }

--- a/backend/src/auth/auth.dto.ts
+++ b/backend/src/auth/auth.dto.ts
@@ -1,5 +1,5 @@
 import { IsEmail, IsNotEmpty, MinLength } from "class-validator";
-import { Expose } from "class-transformer";
+import { Transform } from "class-transformer";
 
 interface RegisterDTOInterface {
   email: string;
@@ -35,49 +35,39 @@ interface PasswordResetDTOInterface {
 }
 
 export class RegisterDTO implements RegisterDTOInterface {
-  @Expose()
   @IsEmail()
   email: string;
 
-  @Expose()
   @IsNotEmpty()
   username: string;
 
-  @Expose()
   @IsNotEmpty()
   fullName: string;
 
-  @Expose()
   @MinLength(8)
   password: string;
 
-  @Expose()
   @MinLength(8)
   confirmPassword: string;
 }
 
 export class LoginDTO implements LoginDTOInterface {
-  @Expose()
   @IsEmail()
   email: string;
 
-  @Expose()
   @MinLength(8)
   password: string;
 }
 
 export class OtpVerificationDTO implements OtpVerificationDTOInterface {
-  @Expose()
   @IsNotEmpty()
   token: string;
 }
 
 export class AccountVerificationDTO implements AccountVerificationDTOInterface {
-  @Expose()
   @IsNotEmpty()
   authSessionId: string;
 
-  @Expose()
   @IsNotEmpty()
   authSessionToken: string;
 }
@@ -85,25 +75,20 @@ export class AccountVerificationDTO implements AccountVerificationDTOInterface {
 export class PasswordResetRequestDTO
   implements PasswordResetRequestDTOInterface
 {
-  @Expose()
   @IsEmail()
   email: string;
 }
 
 export class PasswordResetDTO implements PasswordResetDTOInterface {
-  @Expose()
   @IsNotEmpty()
   sessionId: string;
 
-  @Expose()
   @IsNotEmpty()
   token: string;
 
-  @Expose()
   @MinLength(8)
   newPassword: string;
 
-  @Expose()
   @MinLength(8)
   confirmNewPassword: string;
 }

--- a/backend/src/blog/blog.dto.ts
+++ b/backend/src/blog/blog.dto.ts
@@ -1,244 +1,246 @@
-import { IsNotEmpty, IsOptional, IsBoolean, IsString, IsUUID, IsArray, IsInt, Min, Max } from "class-validator";
+import { IsNotEmpty, IsOptional, IsBoolean, IsString, IsUUID, IsArray, IsInt, Min, Max, ValidateIf, Allow } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
-import { Transform, Type, Expose } from "class-transformer";
+import { Transform, Type } from "class-transformer";
 
 // Blog Post DTOs
 export class BlogPostDTO {
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   id: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   title: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   description: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   content: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   authorId: string;
 
   @ApiProperty()
-  @Expose()
+  @ValidateIf((o) => o.categoryId !== null)
+  @IsUUID()
   categoryId: string | null;
 
   @ApiProperty()
-  @Expose()
+  @ValidateIf((o) => o.coverImageId !== null)
+  @IsUUID()
   coverImageId: string | null;
 
   @ApiProperty()
-  @Expose()
+  @IsBoolean()
   featured: boolean;
 
   @ApiProperty()
-  @Expose()
+  @IsBoolean()
   published: boolean;
 
   @ApiProperty()
-  @Expose()
+  @IsBoolean()
   archived: boolean;
 
   @ApiProperty()
-  @Expose()
+  @Allow()
   createdAt: Date;
 
   @ApiProperty()
-  @Expose()
+  @ValidateIf((o) => o.updatedAt !== null)
+  @Allow()
   updatedAt: Date | null;
 }
 
 export class CreateBlogPostDTO {
   @IsNotEmpty()
   @IsString()
-  @Expose()
   title: string;
 
   @IsNotEmpty()
   @IsString()
-  @Expose()
   description: string;
 
   @IsNotEmpty()
   @IsString()
-  @Expose()
   content: string;
 
   @IsOptional()
   @IsUUID()
-  @Expose()
   categoryId?: string;
 
   @IsOptional()
   @IsUUID()
-  @Expose()
   coverImageId?: string;
 
   @IsOptional()
   @IsBoolean()
-  @Expose()
   featured?: boolean;
 
   @IsOptional()
   @IsBoolean()
-  @Expose()
   published?: boolean;
 
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  @Expose()
   tags?: string[];
 }
 
 export class UpdateBlogPostDTO {
   @IsOptional()
   @IsString()
-  @Expose()
   title?: string;
 
   @IsOptional()
   @IsString()
-  @Expose()
   description?: string;
 
   @IsOptional()
   @IsString()
-  @Expose()
   content?: string;
 
   @IsOptional()
   @IsUUID()
-  @Expose()
   categoryId?: string;
 
   @IsOptional()
   @IsUUID()
-  @Expose()
   coverImageId?: string;
 
   @IsOptional()
   @IsBoolean()
-  @Expose()
   featured?: boolean;
 
   @IsOptional()
   @IsBoolean()
-  @Expose()
   published?: boolean;
 
   @IsOptional()
   @IsBoolean()
-  @Expose()
   archived?: boolean;
 
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  @Expose()
   tags?: string[];
 }
 
 // Comment DTOs
 export class BlogCommentDTO {
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   id: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   postId: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   authorId: string;
 
   @ApiProperty()
-  @Expose()
+  @ValidateIf((o) => o.parentId !== null)
+  @IsUUID()
   parentId: string | null;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   content: string;
 }
 
 export class CreateCommentDTO {
   @IsNotEmpty()
   @IsString()
-  @Expose()
   content: string;
 
   @IsOptional()
   @IsUUID()
-  @Expose()
   parentId?: string;
 }
 
 export class UpdateCommentDTO {
   @IsNotEmpty()
   @IsString()
-  @Expose()
   content: string;
 }
 
 // Like DTOs
 export class BlogLikeDTO {
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   id: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   likerId: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   postId: string;
 
   @ApiProperty()
-  @Expose()
+  @Allow()
   likedAt: Date;
 }
 
 export class ToggleLikeResponseDTO {
   @ApiProperty({ description: 'Whether the post is now liked or not' })
-  @Expose()
+  @IsBoolean()
   liked: boolean;
 
   @ApiProperty({ required: false, description: 'The like object if the post was liked' })
-  @Expose()
+  @IsOptional()
+  @Allow()
   like?: BlogLikeDTO;
 
   @ApiProperty({ description: 'Success message' })
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   message: string;
 }
 
 // View DTOs
 export class BlogViewDTO {
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   id: string;
 
   @ApiProperty()
-  @Expose()
+  @ValidateIf((o) => o.viewerId !== null)
+  @IsString()
   viewerId: string | null;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   postId: string;
 
   @ApiProperty()
-  @Expose()
+  @Allow()
   viewedAt: Date;
 
   @ApiProperty()
-  @Expose()
+  @IsInt()
+  @Min(0)
   viewTime: number;
 }
 
@@ -247,58 +249,59 @@ export class CreateViewDTO {
   @IsInt()
   @Min(0)
   @Max(86400) // Max 24 hours in seconds
-  @Expose()
   viewTime?: number;
 }
 
 // Category DTOs
 export class BlogCategoryDTO {
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   id: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   name: string;
 }
 
 export class CreateCategoryDTO {
   @IsNotEmpty()
   @IsString()
-  @Expose()
   name: string;
 }
 
 export class UpdateCategoryDTO {
   @IsNotEmpty()
   @IsString()
-  @Expose()
   name: string;
 }
 
 // Tag DTOs
 export class BlogTagDTO {
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   id: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   name: string;
 
   @ApiProperty()
-  @Expose()
+  @IsNotEmpty()
+  @IsString()
   userId: string;
 
   @ApiProperty()
-  @Expose()
+  @Allow()
   createdAt: Date;
 }
 
 export class CreateTagDTO {
   @IsNotEmpty()
   @IsString()
-  @Expose()
   name: string;
 }
 // Query DTOs
@@ -307,7 +310,6 @@ export class GetBlogPostsQueryDTO {
   @IsInt()
   @Min(0)
   @Type(() => Number)
-  @Expose()
   offset?: number = 0;
 
   @IsOptional()
@@ -315,32 +317,26 @@ export class GetBlogPostsQueryDTO {
   @Min(1)
   @Max(100)
   @Type(() => Number)
-  @Expose()
   limit?: number = 20;
 
   @IsOptional()
   @IsUUID()
-  @Expose()
   categoryId?: string;
 
   @IsOptional()
   @IsString()
-  @Expose()
   tag?: string;
 
   @IsOptional()
   @IsBoolean()
   @Transform(({value}) => value === 'true')
-  @Expose()
   featured?: boolean;
 
   @IsOptional()
   @IsString()
-  @Expose()
   authorId?: string;
 
   @IsOptional()
   @IsString()
-  @Expose()
   query?: string;
 }

--- a/backend/src/users/users.dto.ts
+++ b/backend/src/users/users.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString, MaxLength, MinLength } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
-import { Expose } from "class-transformer";
+import { Transform, Type } from "class-transformer";
 import { User } from "@/core/db/schema";
 
 export interface UserDTO {
@@ -45,7 +45,6 @@ export interface UserBanResponseDTO {
 }
 
 export class UpdateUserInfoDTO {
-  @Expose()
   @ApiProperty({
     description: "The user's full name",
     example: "John Doe",
@@ -60,7 +59,6 @@ export class UpdateUserInfoDTO {
 }
 
 export class GetUsersDTO {
-  @Expose()
   @ApiProperty({
     description: "Maximum number of users to return",
     example: 20,
@@ -70,7 +68,6 @@ export class GetUsersDTO {
   })
   limit?: number = 20;
 
-  @Expose()
   @ApiProperty({
     description: "Number of users to skip for pagination",
     example: 0,


### PR DESCRIPTION
- Remove @Expose() decorators from all DTO classes across blog, auth, users, and accessmgt modules
- Add appropriate class-validator decorators based on field requirements:
  - @IsNotEmpty() + @IsString() for required string fields
  - @IsOptional() for optional input fields
  - @ValidateIf() for nullable fields that should be validated when present
  - @Allow() for system-generated fields like timestamps
- Update imports to remove unused Expose and add ValidateIf, Allow
- Improve data validation and type safety across API layer
- Ensure consistent validation patterns for Create/Update/Response DTOs